### PR TITLE
feat: persist theme across tools

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,15 +4,8 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Tile-it</title>
+<link rel="stylesheet" href="styles/theme.css">
 <style>
-  :root {
-    --bg: #1a1b26; --panel: #151a2a; --border: #2a2f45; --text: #e7eaf3; --muted: #9aa3ba; --accent: #3b82f6;
-    --grid-bg: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20"><path d="M10 0v20M0 10h20" stroke-width="0.5" stroke="%232a2f45"/></svg>');
-  }
-  .light-mode {
-    --bg: #f0f2f5; --panel: #ffffff; --border: #d9dce1; --text: #1f2328; --muted: #656d76; --accent: #0969da;
-    --grid-bg: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20"><path d="M10 0v20M0 10h20" stroke-width="0.5" stroke="%23d9dce1"/></svg>');
-  }
   *{ box-sizing:border-box }
   body{ margin:0; font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial; background-color:var(--bg); background-image:var(--grid-bg); color:var(--text); }
   .wrap{ max-width:1200px; margin:0 auto; padding:16px; }

--- a/repeat-grid/index.html
+++ b/repeat-grid/index.html
@@ -4,17 +4,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Repeat Grid Tool - Adobe XD Style</title>
+    <link rel="stylesheet" href="../styles/theme.css">
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
 
-        :root {
-          --bg:#0f1220;
-          --panel:#151a2a;
-          --border:#2a2f45;
-          --text:#ffffff;
-          --muted:#9aa3ba;
-          --accent:#ffffff;
-        }
         * {
             margin: 0;
             padding: 0;
@@ -281,6 +274,7 @@
 <body>
     <div class="toolbar">
         <h2>Repeat Grid Tool</h2>
+        <label style="display:flex; align-items:center; gap:6px;"><input id="themeToggle" type="checkbox" /> Light Mode</label>
 
         <div class="drop-zone" id="dropZone">
             <div>Drop PNG/JPG here</div>
@@ -829,6 +823,24 @@
             };
             reader.readAsText(file);
         });
+    </script>
+    <script>
+      const themeToggle = document.getElementById('themeToggle');
+      const body = document.body;
+      const savedTheme = localStorage.getItem('theme');
+      if (savedTheme === 'light') {
+        body.classList.add('light-mode');
+        themeToggle.checked = true;
+      }
+      themeToggle.addEventListener('change', () => {
+        if (themeToggle.checked) {
+          body.classList.add('light-mode');
+          localStorage.setItem('theme', 'light');
+        } else {
+          body.classList.remove('light-mode');
+          localStorage.setItem('theme', 'dark');
+        }
+      });
     </script>
     <script>
       window.addEventListener('DOMContentLoaded', () => {

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1,0 +1,19 @@
+:root {
+  --bg: #1a1b26;
+  --panel: #151a2a;
+  --border: #2a2f45;
+  --text: #e7eaf3;
+  --muted: #9aa3ba;
+  --accent: #3b82f6;
+  --grid-bg: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20"><path d="M10 0v20M0 10h20" stroke-width="0.5" stroke="%232a2f45"/></svg>');
+}
+
+.light-mode {
+  --bg: #f0f2f5;
+  --panel: #ffffff;
+  --border: #d9dce1;
+  --text: #1f2328;
+  --muted: #656d76;
+  --accent: #0969da;
+  --grid-bg: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20"><path d="M10 0v20M0 10h20" stroke-width="0.5" stroke="%23d9dce1"/></svg>');
+}


### PR DESCRIPTION
## Summary
- centralize light and dark color variables in `styles/theme.css`
- load saved theme and persist toggle state in the Repeat Grid tool
- include shared theme stylesheet on main page and keep theme choice in localStorage

## Testing
- `npm test` *(fails: enoent: no such file or directory, open '/workspace/Tile_it/package.json')*


------
https://chatgpt.com/codex/tasks/task_b_68aca7829b448325bc3c7e0795184c59