### PR TITLE
feat: persist repeat-grid settings in project file

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,6 +125,9 @@
             <h2 style="margin:0 0 8px 0">Tools</h2>
             <a href="./repeat-grid/index.html" id="repeatGridLink" class="btn" style="text-decoration: none; display: block; text-align: center;">Repeat Grid Tool</a>
             <button id="sendToGridBtn" class="btn" style="margin-top: 8px; width: 100%;">Send to Repeat Grid</button>
+            <button id="saveProjectBtn" class="btn secondary" style="margin-top: 8px; width: 100%;">Save Project</button>
+            <button id="loadProjectBtn" class="btn ghost" style="margin-top: 8px; width: 100%;">Load Project</button>
+            <input type="file" id="loadProjectInput" accept="application/json" style="display:none" />
         </div>
       </div>
     </div>
@@ -162,6 +165,11 @@
   const deleteBtn = document.getElementById('deleteBtn');
   const upBtn = document.getElementById('upBtn');
   const downBtn = document.getElementById('downBtn');
+  const saveProjectBtn = document.getElementById('saveProjectBtn');
+  const loadProjectBtn = document.getElementById('loadProjectBtn');
+  const loadProjectInput = document.getElementById('loadProjectInput');
+
+  const PROJECT_KEY = 'tileProject';
 
   // ====== Utils ======
   const uid = (()=>{ let i=1; return ()=> i++; })();
@@ -171,6 +179,10 @@
   function deepClone(obj){ return JSON.parse(JSON.stringify(obj)); }
   function snapshot(){ return { layers: deepClone(layers), selectedIds: deepClone(selectedIds), canvasSize:{w:canvas.width,h:canvas.height}, bg:{show:bgToggle.checked, color:bgColorInput.value} }; }
   function applySnapshot(s){ canvas.width = s.canvasSize.w; canvas.height = s.canvasSize.h; bgToggle.checked = !!s.bg.show; bgColorInput.value = s.bg.color; layers = deepClone(s.layers); selectedIds = s.selectedIds || []; currentWrap={ox:0,oy:0}; Array.from(tilePresets.children).forEach(b=> b.classList.toggle('active', parseInt(b.dataset.size)===canvas.width)); updateZoom(); renderLayers(); draw(); updateUndoUI(); }
+
+  function getGridConfig(){ const g = localStorage.getItem('gridConfig'); return g ? JSON.parse(g) : null; }
+  function projectSnapshot(){ const data = { tile: snapshot(), grid: getGridConfig() }; localStorage.setItem(PROJECT_KEY, JSON.stringify(data)); return data; }
+  function applyProject(p){ if(p.tile) applySnapshot(p.tile); else applySnapshot(p); if(p.grid) localStorage.setItem('gridConfig', JSON.stringify(p.grid)); }
   function pushHistory(){ history.push(snapshot()); if(history.length>HISTORY_LIMIT) history.shift(); redoStack.length = 0; updateUndoUI(); }
   function updateUndoUI(){ undoBtn.disabled = history.length<=1; redoBtn.disabled = redoStack.length===0; }
   function undo(){ if(history.length<=1) return; const curr = history.pop(); redoStack.push(curr); const prev = history[history.length-1]; applySnapshot(prev); }
@@ -218,15 +230,15 @@
   exportCustom.addEventListener('input', ()=>{ estTime.textContent = 'Estimated time: ' + estimateTime(getExportSize()); });
   exportBtn.addEventListener('click', ()=>{ if(!layers.length){ alert('Add at least one layer.'); return; } const size = getExportSize() || 1000; const off=document.createElement('canvas'); off.width=size; off.height=size; const octx=off.getContext('2d'); if(bgToggle.checked){ octx.fillStyle=bgColorInput.value; octx.fillRect(0,0,size,size); } const sx=size/canvas.width, sy=size/canvas.height; for(const L of layers){ if(!L.visible) continue; const A=getAsset(L.assetId); if(!A) continue; const w=A.w*L.scale*sx, h=A.h*L.scale*sy; const x=L.x*sx, y=L.y*sy; const rad=L.rot*Math.PI/180; const pts=[[0,0],[-size,0],[size,0],[0,-size],[0,size],[-size,-size],[size,-size],[-size,size],[size,size]]; for(const [ox,oy] of pts){ octx.save(); octx.translate(x+ox,y+oy); octx.rotate(rad); octx.scale(L.flipH?-1:1, L.flipV?-1:1); octx.drawImage(A.img,-w/2,-h/2,w,h); octx.restore(); } } const a=document.createElement('a'); const base=(fileNameInput.value||'tile').replace(/[^a-z0-9_\-]+/gi,'_'); a.href=off.toDataURL('image/png'); a.download=`${base}_${size}${bgToggle.checked?'':'_transparent'}.png`; a.click(); });
   fileInput.addEventListener('change', async (e)=>{ const files=Array.from(e.target.files||[]); if(!files.length) return; for(const f of files){ const url=URL.createObjectURL(f); const img=new Image(); img.crossOrigin='anonymous'; img.src=url; await (img.decode?img.decode():new Promise(res=>{ img.onload=res; })); const id=uid(); assets.push({ id, img, w: img.naturalWidth||img.width, h: img.naturalHeight||img.height, name:f.name }); } renderAssets(); const cols=Math.ceil(Math.sqrt(files.length)); const rows=Math.ceil(files.length/cols); let i=0; const tileW=canvas.width, tileH=canvas.height; for(const a of assets.slice(-files.length)){ const cx = ((i%cols)+0.5)*(tileW/cols); const cy = (Math.floor(i/cols)+0.5)*(tileH/rows); const id=uid(); const s=Math.min(1, (tileW/cols)/(a.w*0.9)); layers.push({ id, assetId:a.id, name:a.name, x:cx, y:cy, scale:s, rot:0, visible:true, locked:false, flipH:false, flipV:false }); i++; } setSelected(layers.length ? [layers[layers.length-1].id] : []); renderLayers(); draw(); estTime.textContent = 'Estimated time: ' + estimateTime(getExportSize()); pushHistory(); });
-  const savedDesign = localStorage.getItem('tileDesign');
-  if (savedDesign) {
+  const savedProject = localStorage.getItem(PROJECT_KEY);
+  if (savedProject) {
     try {
-      applySnapshot(JSON.parse(savedDesign));
+      applyProject(JSON.parse(savedProject));
       pushHistory();
     } catch (e) {
-      console.error('Failed to restore tile design', e);
+      console.error('Failed to restore project', e);
+      updateZoom(); renderLayers(); draw(); pushHistory();
     }
-    localStorage.removeItem('tileDesign');
   } else {
     updateZoom(); renderLayers(); draw(); pushHistory();
   }
@@ -251,12 +263,12 @@
     }
   });
   repeatGridLink.addEventListener('click', () => {
-    localStorage.setItem('tileDesign', JSON.stringify(snapshot()));
+    projectSnapshot();
   });
   sendToGridBtn.addEventListener('click', () => {
     const mainCanvas = document.getElementById('tile');
     if (mainCanvas) {
-      localStorage.setItem('tileDesign', JSON.stringify(snapshot()));
+      projectSnapshot();
       const exportSize = mainCanvas.width;
       const offscreenCanvas = document.createElement('canvas');
       offscreenCanvas.width = exportSize;
@@ -291,6 +303,34 @@
       localStorage.setItem('imageToSendToGrid', dataUrl);
       window.location.href = 'repeat-grid/index.html';
     }
+  });
+
+  saveProjectBtn.addEventListener('click', () => {
+    const data = projectSnapshot();
+    const blob = new Blob([JSON.stringify(data, null, 2)], {type:'application/json'});
+    const a = document.createElement('a');
+    const base = (fileNameInput.value||'tile').replace(/[^a-z0-9_\-]+/gi,'_');
+    a.href = URL.createObjectURL(blob);
+    a.download = `${base}.json`;
+    a.click();
+    URL.revokeObjectURL(a.href);
+  });
+
+  loadProjectBtn.addEventListener('click', ()=> loadProjectInput.click());
+  loadProjectInput.addEventListener('change', (e)=>{
+    const file = e.target.files[0];
+    if(!file) return;
+    const reader = new FileReader();
+    reader.onload = ()=>{
+      try{
+        const data = JSON.parse(reader.result);
+        applyProject(data);
+        pushHistory();
+      }catch(err){
+        alert('Invalid project file');
+      }
+    };
+    reader.readAsText(file);
   });
 </script>
 </body>

--- a/repeat-grid/index.html
+++ b/repeat-grid/index.html
@@ -349,6 +349,21 @@
             spacingIndex: -1
         };
 
+        const PROJECT_KEY = 'tileProject';
+        function gridSnapshot(){
+            return { ...gridData, image: currentImage };
+        }
+        function saveGridToLocal(){
+            const grid = gridSnapshot();
+            localStorage.setItem('gridConfig', JSON.stringify(grid));
+            let tile = null;
+            try{
+                const existing = JSON.parse(localStorage.getItem(PROJECT_KEY) || 'null');
+                tile = existing && existing.tile ? existing.tile : null;
+            }catch{}
+            localStorage.setItem(PROJECT_KEY, JSON.stringify({ tile, grid }));
+        }
+
         // Element references
         const canvas = document.getElementById('canvas');
         const originalElement = document.getElementById('originalElement');
@@ -411,6 +426,7 @@
                 elementPreview.style.backgroundPosition = 'center';
 
                 repeatGridBtn.disabled = false;
+                saveGridToLocal();
             };
             reader.readAsDataURL(file);
         }
@@ -640,6 +656,7 @@
                 H Spacing: ${Math.round(gridData.horizontalSpacing)}px<br>
                 V Spacing: ${Math.round(gridData.verticalSpacing)}px
             `;
+            saveGridToLocal();
         }
 
         function resetGrid() {
@@ -655,13 +672,18 @@
             repeatGridBtn.disabled = currentImage === null;
             resetBtn.disabled = true;
             gridControls.style.display = 'none';
+            saveGridToLocal();
         }
 
         function exportGrid() {
+            let tile = null;
+            try {
+                const existing = JSON.parse(localStorage.getItem(PROJECT_KEY) || 'null');
+                tile = existing && existing.tile ? existing.tile : null;
+            } catch {}
             const data = {
-                ...gridData,
-                hasImage: currentImage !== null,
-                image: currentImage,
+                tile,
+                grid: gridSnapshot(),
                 timestamp: new Date().toISOString()
             };
 
@@ -789,34 +811,36 @@
             const reader = new FileReader();
             reader.onload = function(e) {
                 try {
-                    const data = JSON.parse(e.target.result);
+                    const parsed = JSON.parse(e.target.result);
+                    const proj = (parsed.grid || parsed.tile) ? parsed : { grid: parsed };
+                    if (proj.grid) {
+                        gridData = { ...gridData, ...proj.grid };
+                        document.getElementById('elementSize').value = proj.grid.elementSize || 100;
+                        document.getElementById('elementText').value = proj.grid.elementText || 'Item';
 
-                    // Restore grid data
-                    gridData = { ...data };
+                        if (proj.grid.image) {
+                            currentImage = proj.grid.image;
+                            originalElement.style.backgroundImage = `url(${currentImage})`;
+                            originalElement.style.backgroundSize = 'cover';
+                            originalElement.style.backgroundPosition = 'center';
+                            originalElement.textContent = '';
 
-                    // Update form values
-                    document.getElementById('elementSize').value = data.elementSize || 100;
-                    document.getElementById('elementText').value = data.elementText || 'Item';
+                            elementPreview.style.backgroundImage = `url(${currentImage})`;
+                            elementPreview.style.backgroundSize = 'cover';
+                            elementPreview.style.backgroundPosition = 'center';
 
-                    // Restore image if exists
-                    if (data.image) {
-                        currentImage = data.image;
-                        originalElement.style.backgroundImage = `url(${currentImage})`;
-                        originalElement.style.backgroundSize = 'cover';
-                        originalElement.style.backgroundPosition = 'center';
-                        originalElement.textContent = '';
+                            repeatGridBtn.disabled = false;
+                        }
 
-                        elementPreview.style.backgroundImage = `url(${currentImage})`;
-                        elementPreview.style.backgroundSize = 'cover';
-                        elementPreview.style.backgroundPosition = 'center';
-
-                        repeatGridBtn.disabled = false;
+                        updateElementSize();
+                        updateElementText();
                     }
-
-                    // Update element size and text
-                    updateElementSize();
-                    updateElementText();
-
+                    if (proj.tile) {
+                        localStorage.setItem(PROJECT_KEY, JSON.stringify({ tile: proj.tile, grid: gridSnapshot() }));
+                        localStorage.setItem('gridConfig', JSON.stringify(gridSnapshot()));
+                    } else {
+                        saveGridToLocal();
+                    }
                     alert('Grid imported successfully!');
                 } catch (error) {
                     alert('Error importing file: ' + error.message);
@@ -845,6 +869,33 @@
     </script>
     <script>
       window.addEventListener('DOMContentLoaded', () => {
+        const projectStr = localStorage.getItem(PROJECT_KEY);
+        if (projectStr) {
+          try {
+            const proj = JSON.parse(projectStr);
+            if (proj.grid) {
+              gridData = { ...gridData, ...proj.grid };
+              document.getElementById('elementSize').value = gridData.elementSize;
+              document.getElementById('elementText').value = gridData.elementText;
+              if (proj.grid.image) {
+                currentImage = proj.grid.image;
+                originalElement.style.backgroundImage = `url(${currentImage})`;
+                originalElement.style.backgroundSize = 'cover';
+                originalElement.style.backgroundPosition = 'center';
+                originalElement.textContent = '';
+
+                elementPreview.style.backgroundImage = `url(${currentImage})`;
+                elementPreview.style.backgroundSize = 'cover';
+                elementPreview.style.backgroundPosition = 'center';
+
+                repeatGridBtn.disabled = false;
+              }
+              updateElementSize();
+              updateElementText();
+              saveGridToLocal();
+            }
+          } catch {}
+        }
         const imageData = localStorage.getItem('imageToSendToGrid');
         if (imageData) {
           try {
@@ -859,6 +910,7 @@
             elementPreview.style.backgroundPosition = 'center';
 
             repeatGridBtn.disabled = false;
+            saveGridToLocal();
           } finally {
             localStorage.removeItem('imageToSendToGrid');
           }


### PR DESCRIPTION
## Summary
- Add project save/load buttons in main editor
- Include repeat-grid configuration in saved project data
- Restore grid settings from project file or localStorage

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68acadc772e08325b50167e8bccbe647