### PR TITLE
feat: refresh dark theme palette

### DIFF
--- a/repeat-grid/index.html
+++ b/repeat-grid/index.html
@@ -122,6 +122,7 @@
         }
 
         .grid-handle:hover {
+            background: #93C5FD;
             transform: scale(1.1);
         }
 
@@ -168,8 +169,8 @@
         }
 
         .btn:hover {
-            background: var(--muted);
-            color: var(--panel);
+            background: #93C5FD;
+            color: var(--bg);
         }
 
         .btn:disabled {
@@ -183,7 +184,7 @@
         }
 
         .btn-success:hover {
-            background: var(--muted);
+            background: #93C5FD;
         }
 
         .btn-danger {
@@ -191,7 +192,7 @@
         }
 
         .btn-danger:hover {
-            background: #c82333;
+            background: #ef5d5d;
         }
 
         .file-input {

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -1,11 +1,22 @@
 :root {
-  --bg: #1a1b26;
-  --panel: #151a2a;
-  --border: #2a2f45;
-  --text: #e7eaf3;
-  --muted: #9aa3ba;
-  --accent: #3b82f6;
-  --grid-bg: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20"><path d="M10 0v20M0 10h20" stroke-width="0.5" stroke="%232a2f45"/></svg>');
+  --grid-bg: #18181B;
+  --bg: #0F1220;
+  --overlay-shadow1: #17171A;
+  --overlay-shadow2: #1E1E21;
+  --panel: #27272A;
+  --panel-depth1: #28282C;
+  --panel-depth2: #28282B;
+  --panel-depth3: #262629;
+  --panel-depth4: #26262A;
+  --border: #1D1D20;
+  --divider1: #212125;
+  --divider2: #232327;
+  --panel-edge: #29292C;
+  --text: #F4F4F5;
+  --muted: #A1A1AA;
+  --text-edge1: #19191C;
+  --text-edge2: #1A1A1D;
+  --accent: #60A5FA;
 }
 
 .light-mode {


### PR DESCRIPTION
## Summary
- overhaul dark theme variables with new color palette
- lighten hover colors to complement the new accent

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68acc6b12e288325aa33f96b6a79565a