### PR TITLE
feat: render transparency pattern behind canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,6 +161,7 @@
   const fileInput = document.getElementById('fileInput');
   const assetThumbs = document.getElementById('assetThumbs');
   const layerList = document.getElementById('layers');
+  const canvasWrap = document.getElementById('canvasWrap');
   const canvas = document.getElementById('tile');
   const ctx = canvas.getContext('2d');
   const tilePresets = document.getElementById('tilePresets');
@@ -187,6 +188,8 @@
   const helpOverlay = document.getElementById('helpOverlay');
   const closeHelpBtn = document.getElementById('closeHelpBtn');
 
+  canvasWrap.classList.toggle('transparent-bg', !bgToggle.checked);
+
   const PROJECT_KEY = 'tileProject';
 
   // ====== Utils ======
@@ -196,7 +199,7 @@
   function setSelected(ids){ selectedIds = Array.isArray(ids) ? ids : [ids]; currentWrap={ox:0,oy:0}; renderLayers(); draw(); }
   function deepClone(obj){ return JSON.parse(JSON.stringify(obj)); }
   function snapshot(){ return { layers: deepClone(layers), selectedIds: deepClone(selectedIds), canvasSize:{w:canvas.width,h:canvas.height}, bg:{show:bgToggle.checked, color:bgColorInput.value} }; }
-  function applySnapshot(s){ canvas.width = s.canvasSize.w; canvas.height = s.canvasSize.h; bgToggle.checked = !!s.bg.show; bgColorInput.value = s.bg.color; layers = deepClone(s.layers); selectedIds = s.selectedIds || []; currentWrap={ox:0,oy:0}; Array.from(tilePresets.children).forEach(b=> b.classList.toggle('active', parseInt(b.dataset.size)===canvas.width)); updateZoom(); renderLayers(); draw(); updateUndoUI(); }
+  function applySnapshot(s){ canvas.width = s.canvasSize.w; canvas.height = s.canvasSize.h; bgToggle.checked = !!s.bg.show; bgColorInput.value = s.bg.color; canvasWrap.classList.toggle('transparent-bg', !bgToggle.checked); layers = deepClone(s.layers); selectedIds = s.selectedIds || []; currentWrap={ox:0,oy:0}; Array.from(tilePresets.children).forEach(b=> b.classList.toggle('active', parseInt(b.dataset.size)===canvas.width)); updateZoom(); renderLayers(); draw(); updateUndoUI(); }
 
   function getGridConfig(){ const g = localStorage.getItem('gridConfig'); return g ? JSON.parse(g) : null; }
   function projectSnapshot(){ const data = { tile: snapshot(), grid: getGridConfig() }; localStorage.setItem(PROJECT_KEY, JSON.stringify(data)); return data; }
@@ -238,7 +241,7 @@
   flipHBtn.addEventListener('click', ()=>{ const top = selectedIds.length ? getLayer(selectedIds[selectedIds.length-1]) : null; if(!top) return; top.flipH=!top.flipH; renderLayers(); draw(); pushHistory(); });
   flipVBtn.addEventListener('click', ()=>{ const top = selectedIds.length ? getLayer(selectedIds[selectedIds.length-1]) : null; if(!top) return; top.flipV=!top.flipV; renderLayers(); draw(); pushHistory(); });
   tilePresets.addEventListener('click',(e)=>{ const b=e.target.closest('button'); if(!b) return; const s=parseInt(b.dataset.size); canvas.width=s; canvas.height=s; Array.from(tilePresets.children).forEach(x=>x.classList.toggle('active', x===b)); draw(); updateZoom(); pushHistory(); });
-  bgToggle.addEventListener('change', ()=>{ draw(); pushHistory(); });
+  bgToggle.addEventListener('change', ()=>{ canvasWrap.classList.toggle('transparent-bg', !bgToggle.checked); draw(); pushHistory(); });
   bgColorInput.addEventListener('change', ()=>{ draw(); pushHistory(); });
   bgColorInput.addEventListener('input', ()=>{ draw(); });
   function updateZoom(){ const z = 0.45; const cssW = Math.max(280, Math.round(canvas.width * z)); canvas.style.width = cssW + 'px'; canvas.style.height = 'auto'; }

--- a/styles/theme.css
+++ b/styles/theme.css
@@ -17,3 +17,9 @@
   --accent: #0969da;
   --grid-bg: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20"><path d="M10 0v20M0 10h20" stroke-width="0.5" stroke="%23d9dce1"/></svg>');
 }
+
+.transparent-bg {
+  background-color: var(--panel);
+  background-image: repeating-conic-gradient(var(--border) 0 25%, transparent 0 50%);
+  background-size: 16px 16px;
+}


### PR DESCRIPTION
## Summary
- add reusable `transparent-bg` class using theme colors for checkerboard pattern
- toggle background class on `#canvasWrap` to show transparency grid when background disabled
- keep pattern intact during snapshot restore and background toggle

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68adde18ab1c83259321de475903ace6