### PR TITLE
Remove tile size presets

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,12 +58,6 @@
       <div class="toolbar">
         <button id="undoBtn" class="btn secondary" disabled>Undo</button>
         <button id="redoBtn" class="btn secondary" disabled>Redo</button>
-        <div class="seg" id="tilePresets">
-          <button data-size="1000" class="active">1000</button>
-          <button data-size="1024">1024</button>
-          <button data-size="2048">2048</button>
-          <button data-size="4096">4096</button>
-        </div>
         <label class="toolbar" style="gap:6px"><input id="bgToggle" type="checkbox" checked /> Background on</label>
         <input id="bgColor" type="color" value="#0f1220" />
         <label class="toolbar" style="gap:6px"><input id="themeToggle" type="checkbox" /> Light Mode</label>
@@ -164,7 +158,6 @@
   const canvasWrap = document.getElementById('canvasWrap');
   const canvas = document.getElementById('tile');
   const ctx = canvas.getContext('2d');
-  const tilePresets = document.getElementById('tilePresets');
   const bgToggle = document.getElementById('bgToggle');
   const bgColorInput = document.getElementById('bgColor');
   const exportSizeSel = document.getElementById('exportSize');
@@ -199,7 +192,7 @@
   function setSelected(ids){ selectedIds = Array.isArray(ids) ? ids : [ids]; currentWrap={ox:0,oy:0}; renderLayers(); draw(); }
   function deepClone(obj){ return JSON.parse(JSON.stringify(obj)); }
   function snapshot(){ return { layers: deepClone(layers), selectedIds: deepClone(selectedIds), canvasSize:{w:canvas.width,h:canvas.height}, bg:{show:bgToggle.checked, color:bgColorInput.value} }; }
-  function applySnapshot(s){ canvas.width = s.canvasSize.w; canvas.height = s.canvasSize.h; bgToggle.checked = !!s.bg.show; bgColorInput.value = s.bg.color; canvasWrap.classList.toggle('transparent-bg', !bgToggle.checked); layers = deepClone(s.layers); selectedIds = s.selectedIds || []; currentWrap={ox:0,oy:0}; Array.from(tilePresets.children).forEach(b=> b.classList.toggle('active', parseInt(b.dataset.size)===canvas.width)); updateZoom(); renderLayers(); draw(); updateUndoUI(); }
+  function applySnapshot(s){ canvas.width = s.canvasSize.w; canvas.height = s.canvasSize.h; bgToggle.checked = !!s.bg.show; bgColorInput.value = s.bg.color; canvasWrap.classList.toggle('transparent-bg', !bgToggle.checked); layers = deepClone(s.layers); selectedIds = s.selectedIds || []; currentWrap={ox:0,oy:0}; updateZoom(); renderLayers(); draw(); updateUndoUI(); }
 
   function getGridConfig(){ const g = localStorage.getItem('gridConfig'); return g ? JSON.parse(g) : null; }
   function projectSnapshot(){ const data = { tile: snapshot(), grid: getGridConfig() }; localStorage.setItem(PROJECT_KEY, JSON.stringify(data)); return data; }
@@ -240,7 +233,6 @@
   redoBtn.addEventListener('click', redo);
   flipHBtn.addEventListener('click', ()=>{ const top = selectedIds.length ? getLayer(selectedIds[selectedIds.length-1]) : null; if(!top) return; top.flipH=!top.flipH; renderLayers(); draw(); pushHistory(); });
   flipVBtn.addEventListener('click', ()=>{ const top = selectedIds.length ? getLayer(selectedIds[selectedIds.length-1]) : null; if(!top) return; top.flipV=!top.flipV; renderLayers(); draw(); pushHistory(); });
-  tilePresets.addEventListener('click',(e)=>{ const b=e.target.closest('button'); if(!b) return; const s=parseInt(b.dataset.size); canvas.width=s; canvas.height=s; Array.from(tilePresets.children).forEach(x=>x.classList.toggle('active', x===b)); draw(); updateZoom(); pushHistory(); });
   bgToggle.addEventListener('change', ()=>{ canvasWrap.classList.toggle('transparent-bg', !bgToggle.checked); draw(); pushHistory(); });
   bgColorInput.addEventListener('change', ()=>{ draw(); pushHistory(); });
   bgColorInput.addEventListener('input', ()=>{ draw(); });


### PR DESCRIPTION
## Summary
- Remove obsolete tile size preset buttons from toolbar
- Clean up associated JavaScript logic and event handlers

## Testing
- `npm test` *(fails: package.json missing)*
- `node --check /tmp/script1.js`
- `node - <<'NODE'
const fs = require('fs');
const html = fs.readFileSync('index.html','utf8');
const match = html.match(/function getExportSize\([^]*?\}\n/);
const funcCode = match[0];
const exportSizeSel = { value: '1024' };
const exportCustom = { value: '' };
eval(funcCode);
console.log('default', getExportSize());
exportCustom.value = '1500';
console.log('custom', getExportSize());
NODE`
- `npm install puppeteer@21.7.0 --no-save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68ade1409a708325b1ad23304ba090ea