### PR TITLE
Remove Repeat Grid UI integration

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,8 +123,6 @@
 
         <div class="card">
             <h2 style="margin:0 0 8px 0">Tools</h2>
-            <a href="./repeat-grid/index.html" id="repeatGridLink" class="btn" style="text-decoration: none; display: block; text-align: center;">Repeat Grid Tool</a>
-            <button id="sendToGridBtn" class="btn" style="margin-top: 8px; width: 100%;">Send to Repeat Grid</button>
             <button id="saveProjectBtn" class="btn secondary" style="margin-top: 8px; width: 100%;">Save Project</button>
             <button id="loadProjectBtn" class="btn ghost" style="margin-top: 8px; width: 100%;">Load Project</button>
             <input type="file" id="loadProjectInput" accept="application/json" style="display:none" />
@@ -264,8 +262,6 @@
 </script>
 <script>
   const themeToggle = document.getElementById('themeToggle');
-  const sendToGridBtn = document.getElementById('sendToGridBtn');
-  const repeatGridLink = document.getElementById('repeatGridLink');
   const body = document.body;
   const savedTheme = localStorage.getItem('theme');
   if (savedTheme === 'light') {
@@ -281,48 +277,7 @@
       localStorage.setItem('theme', 'dark');
     }
   });
-  repeatGridLink.addEventListener('click', () => {
-    projectSnapshot();
-  });
-  sendToGridBtn.addEventListener('click', () => {
-    const mainCanvas = document.getElementById('tile');
-    if (mainCanvas) {
-      projectSnapshot();
-      const exportSize = mainCanvas.width;
-      const offscreenCanvas = document.createElement('canvas');
-      offscreenCanvas.width = exportSize;
-      offscreenCanvas.height = exportSize;
-      const octx = offscreenCanvas.getContext('2d');
-      if (bgToggle.checked) {
-        octx.fillStyle = bgColorInput.value;
-        octx.fillRect(0, 0, exportSize, exportSize);
-      }
-      const sx = exportSize / mainCanvas.width;
-      const sy = exportSize / mainCanvas.height;
-      for (const L of layers) {
-        if (!L.visible) continue;
-        const A = getAsset(L.assetId);
-        if (!A) continue;
-        const w = A.w * L.scale * sx;
-        const h = A.h * L.scale * sy;
-        const x = L.x * sx;
-        const y = L.y * sy;
-        const rad = L.rot * Math.PI / 180;
-        const pts = [[0, 0], [-exportSize, 0], [exportSize, 0], [0, -exportSize], [0, exportSize], [-exportSize, -exportSize], [exportSize, -exportSize], [-exportSize, exportSize], [exportSize, exportSize]];
-        for (const [ox, oy] of pts) {
-          octx.save();
-          octx.translate(x + ox, y + oy);
-          octx.rotate(rad);
-          octx.scale(L.flipH ? -1 : 1, L.flipV ? -1 : 1);
-          octx.drawImage(A.img, -w / 2, -h / 2, w, h);
-          octx.restore();
-        }
-      }
-      const dataUrl = offscreenCanvas.toDataURL('image/png');
-      localStorage.setItem('imageToSendToGrid', dataUrl);
-      window.location.href = 'repeat-grid/index.html';
-    }
-  });
+  // Repeat Grid integration removed
 
   saveProjectBtn.addEventListener('click', () => {
     const data = projectSnapshot();

--- a/repeat-grid/index.html
+++ b/repeat-grid/index.html
@@ -852,25 +852,6 @@
             }
           } catch {}
         }
-        const imageData = localStorage.getItem('imageToSendToGrid');
-        if (imageData) {
-          try {
-            currentImage = imageData;
-            originalElement.style.backgroundImage = `url(${currentImage})`;
-            originalElement.style.backgroundSize = 'cover';
-            originalElement.style.backgroundPosition = 'center';
-            originalElement.textContent = '';
-
-            elementPreview.style.backgroundImage = `url(${currentImage})`;
-            elementPreview.style.backgroundSize = 'cover';
-            elementPreview.style.backgroundPosition = 'center';
-
-            repeatGridBtn.disabled = false;
-            saveGridToLocal();
-          } finally {
-            localStorage.removeItem('imageToSendToGrid');
-          }
-        }
       });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- drop obsolete Repeat Grid link and button from main UI
- strip related event handlers, project snapshots and localStorage usage
- clean repeat-grid page of now-unused `imageToSendToGrid` storage logic

## Testing
- `npm test` *(fails: could not read package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_b_68af35aea8588325b4205d6d2386ce60