### PR TITLE
Fix checkerboard overflow on tile canvas

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,7 +155,6 @@
   const fileInput = document.getElementById('fileInput');
   const assetThumbs = document.getElementById('assetThumbs');
   const layerList = document.getElementById('layers');
-  const canvasWrap = document.getElementById('canvasWrap');
   const canvas = document.getElementById('tile');
   const ctx = canvas.getContext('2d');
   const bgToggle = document.getElementById('bgToggle');
@@ -182,7 +181,7 @@
   const helpOverlay = document.getElementById('helpOverlay');
   const closeHelpBtn = document.getElementById('closeHelpBtn');
 
-  canvasWrap.classList.toggle('transparent-bg', !bgToggle.checked);
+  canvas.classList.toggle('transparent-bg', !bgToggle.checked);
 
   const PROJECT_KEY = 'tileProject';
 
@@ -193,7 +192,7 @@
   function setSelected(ids){ selectedIds = Array.isArray(ids) ? ids : [ids]; currentWrap={ox:0,oy:0}; renderLayers(); draw(); }
   function deepClone(obj){ return JSON.parse(JSON.stringify(obj)); }
   function snapshot(){ return { layers: deepClone(layers), selectedIds: deepClone(selectedIds), canvasSize:{w:canvas.width,h:canvas.height}, bg:{show:bgToggle.checked, color:bgColorInput.value} }; }
-  function applySnapshot(s){ canvas.width = s.canvasSize.w; canvas.height = s.canvasSize.h; bgToggle.checked = !!s.bg.show; bgColorInput.value = s.bg.color; canvasWrap.classList.toggle('transparent-bg', !bgToggle.checked); layers = deepClone(s.layers); selectedIds = s.selectedIds || []; currentWrap={ox:0,oy:0}; updateZoom(); renderLayers(); draw(); updateUndoUI(); }
+  function applySnapshot(s){ canvas.width = s.canvasSize.w; canvas.height = s.canvasSize.h; bgToggle.checked = !!s.bg.show; bgColorInput.value = s.bg.color; canvas.classList.toggle('transparent-bg', !bgToggle.checked); layers = deepClone(s.layers); selectedIds = s.selectedIds || []; currentWrap={ox:0,oy:0}; updateZoom(); renderLayers(); draw(); updateUndoUI(); }
 
   function getGridConfig(){ const g = localStorage.getItem('gridConfig'); return g ? JSON.parse(g) : null; }
   function projectSnapshot(){ const data = { tile: snapshot(), grid: getGridConfig() }; localStorage.setItem(PROJECT_KEY, JSON.stringify(data)); return data; }
@@ -234,7 +233,7 @@
   redoBtn.addEventListener('click', redo);
   flipHBtn.addEventListener('click', ()=>{ const top = selectedIds.length ? getLayer(selectedIds[selectedIds.length-1]) : null; if(!top) return; top.flipH=!top.flipH; renderLayers(); draw(); pushHistory(); });
   flipVBtn.addEventListener('click', ()=>{ const top = selectedIds.length ? getLayer(selectedIds[selectedIds.length-1]) : null; if(!top) return; top.flipV=!top.flipV; renderLayers(); draw(); pushHistory(); });
-  bgToggle.addEventListener('change', ()=>{ canvasWrap.classList.toggle('transparent-bg', !bgToggle.checked); draw(); pushHistory(); });
+  bgToggle.addEventListener('change', ()=>{ canvas.classList.toggle('transparent-bg', !bgToggle.checked); draw(); pushHistory(); });
   bgColorInput.addEventListener('change', ()=>{ draw(); pushHistory(); });
   bgColorInput.addEventListener('input', ()=>{ draw(); });
   function updateZoom(){ const z = 0.45; const cssW = Math.max(280, Math.round(canvas.width * z)); canvas.style.width = cssW + 'px'; canvas.style.height = 'auto'; }


### PR DESCRIPTION
## Summary
- ensure transparent checkerboard background applies only to the tile canvas so pattern doesn't spill into the surrounding card

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b01fb5dd388325ae14265a8e0e060d