### PR TITLE
feat: refine transparent background checkerboard

### DIFF
--- a/styles/theme.css
+++ b/styles/theme.css
@@ -19,7 +19,13 @@
 }
 
 .transparent-bg {
-  background-color: var(--panel);
-  background-image: repeating-conic-gradient(var(--border) 0 25%, transparent 0 50%);
+  background-image:
+    linear-gradient(45deg, #ccc 25%, transparent 25%),
+    linear-gradient(-45deg, #ccc 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #ccc 75%),
+    linear-gradient(-45deg, transparent 75%, #ccc 75%);
   background-size: 16px 16px;
+  background-position: 0 0, 0 0, 8px 8px, 8px 8px;
+  background-origin: border-box;
+  background-clip: padding-box;
 }


### PR DESCRIPTION
## Summary
- replace transparent background placeholder with a standard gray/white checkerboard pattern
- confine pattern to canvas area using background-origin and background-clip

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b02b4b7ec08325851519e4b0de074d