### PR TITLE
fix: improve checkerboard background using explicit gradients

### DIFF
--- a/styles/theme.css
+++ b/styles/theme.css
@@ -20,6 +20,11 @@
 
 .transparent-bg {
   background-color: var(--panel);
-  background-image: repeating-conic-gradient(var(--border) 0 25%, transparent 0 50%);
-  background-size: 16px 16px;
+  background-image:
+    linear-gradient(45deg, #ccc 25%, #fff 25%, #fff 50%, #ccc 50%, #ccc 75%, #fff 75%, #fff),
+    linear-gradient(45deg, #ccc 25%, #fff 25%, #fff 50%, #ccc 50%, #ccc 75%, #fff 75%, #fff);
+  background-size: 20px 20px;
+  background-position: 0 0, 10px 10px;
+  background-origin: border-box;
+  background-clip: padding-box;
 }


### PR DESCRIPTION
## Summary
- replace transparent checkerboard with layered gray/white gradients
- ensure background pattern clips to canvas using border-box origin and padding-box clip

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npx --yes --package puppeteer node -e ...` *(fails: 403 Forbidden - GET https://registry.npmjs.org/puppeteer)*

------
https://chatgpt.com/codex/tasks/task_b_68b02ff6b09c832590cd0e11275e56d6