### PR TITLE
Add Supabase auth gate

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,25 @@
   }
 </script>
 
+<script src="https://unpkg.com/@supabase/supabase-js@2"></script>
+<script>
+  const supabaseUrl = 'https://bpwlgiiksovtccsrojko.supabase.co';
+  const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJwd2xnaWlrc292dGNjc3JvamtvIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTY3MDc1NzIsImV4cCI6MjA3MjI4MzU3Mn0.Vrq9hTdWnGH0E6WQ0HvR_J8k7qax96FqkurJcr7VQkk';
+  const supabaseClient = supabase.createClient(supabaseUrl, supabaseAnonKey);
+
+  supabaseClient.auth.getSession().then(({ data: { session } }) => {
+    if (!session) {
+      window.location.href = '/login.html';
+    }
+  });
+
+  supabaseClient.auth.onAuthStateChange((_event, session) => {
+    if (!session) {
+      window.location.href = '/login.html';
+    }
+  });
+</script>
+
 </head>
 <body>
   <div class="wrap">

--- a/login.html
+++ b/login.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Login</title>
+  <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
+  <script>
+    const supabaseUrl = 'https://bpwlgiiksovtccsrojko.supabase.co';
+    const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJwd2xnaWlrc292dGNjc3JvamtvIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTY3MDc1NzIsImV4cCI6MjA3MjI4MzU3Mn0.Vrq9hTdWnGH0E6WQ0HvR_J8k7qax96FqkurJcr7VQkk';
+    const supabaseClient = supabase.createClient(supabaseUrl, supabaseAnonKey);
+
+    async function checkSession() {
+      const { data: { session } } = await supabaseClient.auth.getSession();
+      if (session) {
+        window.location.href = '/';
+      }
+    }
+
+    checkSession();
+
+    supabaseClient.auth.onAuthStateChange((_event, session) => {
+      if (session) {
+        window.location.href = '/';
+      }
+    });
+
+    async function handleLogin(event) {
+      event.preventDefault();
+      const email = document.getElementById('email').value;
+      const password = document.getElementById('password').value;
+      const { error } = await supabaseClient.auth.signInWithPassword({ email, password });
+      if (error) {
+        alert(error.message);
+      } else {
+        window.location.href = '/';
+      }
+    }
+  </script>
+  <style>
+    body { font-family: system-ui, sans-serif; display:flex; justify-content:center; align-items:center; height:100vh; margin:0; }
+    form { display:flex; flex-direction:column; gap:8px; width:300px; }
+    input, button { padding:8px; }
+    button { cursor:pointer; }
+  </style>
+</head>
+<body>
+  <form onsubmit="handleLogin(event)">
+    <input id="email" type="email" placeholder="Email" required />
+    <input id="password" type="password" placeholder="Password" required />
+    <button type="submit">Login</button>
+  </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Supabase client load and session checks to index
- add simple login page using Supabase auth
- use provided Supabase project URL and anon key

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b593ea3dcc8325b8c7d384333a155b