### PR TITLE
Add Supabase auth redirect and cache login page

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
     navigator.serviceWorker.register('sw.js');
   }
 </script>
+<script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
 
 </head>
 <body>
@@ -148,6 +149,13 @@
   </div>
 
   <script>
+(async () => {
+  const supabaseClient = window.supabase.createClient('https://example.supabase.co', 'public-anon-key');
+  const { data: { session } } = await supabaseClient.auth.getSession();
+  if (!session) {
+    location.href = "/login.html";
+    return;
+  }
   // ====== State ======
   const assets = [];
   let layers = [];
@@ -267,8 +275,7 @@
   } else {
     updateZoom(); renderLayers(); draw(); pushHistory();
   }
-</script>
-<script>
+
   const themeToggle = document.getElementById('themeToggle');
   const body = document.body;
   const savedTheme = localStorage.getItem('theme');
@@ -324,6 +331,7 @@
   helpOverlay.addEventListener('click', (e) => {
     if (e.target === helpOverlay) helpOverlay.style.display = 'none';
   });
+})();
 </script>
 </body>
 </html>

--- a/sw.js
+++ b/sw.js
@@ -4,6 +4,7 @@ self.addEventListener("install", e => {
       return cache.addAll([
         "/",
         "/index.html",
+        "/login.html",
         "/manifest.json",
         "/sw.js",
         "/icon-192.png",


### PR DESCRIPTION
## Summary
- load Supabase client in index.html
- check for session and redirect to /login.html if missing before running app
- cache login.html in service worker for offline use

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b59c0d85a483258cb2dfc1f67b8e13