### PR TITLE
Hide Tile It app until authentication is validated

### DIFF
--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,13 @@
+import { createClient } from "https://esm.run/@supabase/supabase-js";
+
+const supabase = createClient(
+  "https://bpwlgiiksovtccsrojko.supabase.co",
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJwd2xnaWlrc292dGNjc3JvamtvIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTY3MDc1NzIsImV4cCI6MjA3MjI4MzU3Mn0.Vrq9hTdWnGH0E6WQ0HvR_J8k7qax96FqkurJcr7VQkk"
+);
+
+(async () => {
+  const { data: { session } } = await supabase.auth.getSession();
+  if (session) {
+    document.getElementById('app').classList.remove('hidden');
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   *{ box-sizing:border-box }
   body{ margin:0; font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial; background-color:var(--bg); background-image:var(--grid-bg); color:var(--text); }
   .wrap{ max-width:1200px; margin:0 auto; padding:16px; }
+  .hidden{display:none}
   .title{ display:flex; justify-content:space-between; align-items:center; gap:12px; margin-bottom:12px }
   .row{ display:grid; grid-template-columns: 320px 1fr 320px; gap:16px }
   .col-left, .col-right{ display:flex; flex-direction:column; gap:16px; }
@@ -53,7 +54,8 @@
 
 </head>
 <body>
-  <div class="wrap">
+  <div id="app" class="hidden">
+    <div class="wrap">
     <div class="title">
       <h1 style="margin:0">Tile-it</h1>
       <div class="toolbar">
@@ -135,15 +137,16 @@
         </div>
       </div>
     </div>
-  </div>
+    </div>
 
-  <div id="helpOverlay" class="overlay">
-    <div class="overlay-content">
-      <h2 style="margin-top:0">Getting Started</h2>
-      <p>Import images using the <strong>Import Images</strong> panel.</p>
-      <p>Manipulate and arrange your images in the <strong>Layers</strong> panel.</p>
-      <p>When you're ready, use the <strong>Export</strong> panel to save your tile.</p>
-      <button id="closeHelpBtn" class="btn secondary" style="margin-top:12px">Close</button>
+    <div id="helpOverlay" class="overlay">
+      <div class="overlay-content">
+        <h2 style="margin-top:0">Getting Started</h2>
+        <p>Import images using the <strong>Import Images</strong> panel.</p>
+        <p>Manipulate and arrange your images in the <strong>Layers</strong> panel.</p>
+        <p>When you're ready, use the <strong>Export</strong> panel to save your tile.</p>
+        <button id="closeHelpBtn" class="btn secondary" style="margin-top:12px">Close</button>
+      </div>
     </div>
   </div>
 
@@ -325,5 +328,6 @@
     if (e.target === helpOverlay) helpOverlay.style.display = 'none';
   });
 </script>
+<script type="module" src="auth.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- wrap app content in #app and hide by default
- add auth.js to reveal app when Supabase session exists

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b5e412e2348325aa5c2c3845ca61fe